### PR TITLE
Changes admin default binding to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ FIELD                             FLAG                               ENV        
 App.Log.Level                     -app-log-level                     APP_LOG_LEVEL                     info
 App.Log.Human                     -app-log-human                     APP_LOG_HUMAN
 App.AdminServer.Enabled           -app-adminserver-enabled           APP_ADMINSERVER_ENABLED           true
-App.AdminServer.Port              -app-adminserver-port              APP_ADMINSERVER_PORT              9000
+App.AdminServer.Addr              -app-adminserver-addr              APP_ADMINSERVER_ADDR              localhost:9000
 App.AdminServer.With.DebugURLs    -app-adminserver-with-debugurls    APP_ADMINSERVER_WITH_DEBUGURLS    true
 App.AdminServer.With.Metrics      -app-adminserver-with-metrics      APP_ADMINSERVER_WITH_METRICS      true
 App.AdminServer.With.Probes       -app-adminserver-with-probes       APP_ADMINSERVER_WITH_PROBES       true

--- a/app.go
+++ b/app.go
@@ -97,7 +97,7 @@ func (app *App) startAdminServer(c Config) {
 	}
 
 	server := http.Server{
-		Addr:              ":" + c.App.AdminServer.Port,
+		Addr:              c.App.AdminServer.Addr,
 		Handler:           mux,
 		ReadHeaderTimeout: 60 * time.Second,
 	}

--- a/config.go
+++ b/config.go
@@ -19,7 +19,7 @@ type Config struct {
 			// Enabled sets the admin server
 			Enabled bool `default:"true"`
 			// DefaultAdminPort is the default port the app will bind the admin HTTP interface.
-			Port string `default:"9000"`
+			Addr string `default:"localhost:9000"`
 			With struct {
 				// DebugURLs sets the debug URLs in the admin server. To disable them, set to false.
 				DebugURLs bool `default:"true"`

--- a/examples/probes/main.go
+++ b/examples/probes/main.go
@@ -41,7 +41,7 @@ func main() {
 	}()
 
 	app.RunAndWait(func(ctx context.Context) error {
-		readinessURL := "http://127.0.0.1:" + cfg.App.AdminServer.Port + "/ready"
+		readinessURL := "http://" + cfg.App.AdminServer.Addr + "/ready"
 		for ctx.Err() == nil {
 			time.Sleep(time.Second)
 

--- a/examples/quickstart/main.go
+++ b/examples/quickstart/main.go
@@ -22,6 +22,7 @@ var (
 func main() {
 	defer app.Recover()
 	app.Bootstrap(version, &cfg)
+
 	app.RunAndWait(func(ctx context.Context) error {
 		<-ctx.Done()
 		return ctx.Err()

--- a/examples/servefiles/main.go
+++ b/examples/servefiles/main.go
@@ -23,7 +23,7 @@ var (
 		// Programs can have any configuration the want.
 
 		HTTP struct {
-			Port string `default:"8000"`
+			Addr string `default:"localhost:8000"`
 		}
 		Dir string `default:"."`
 	}
@@ -48,14 +48,14 @@ func main() {
 	app.RunAndWait(func(_ context.Context) error {
 		log.Info().
 			Str("dir", cfg.Dir).
-			Str("port", cfg.HTTP.Port).
+			Str("port", cfg.HTTP.Addr).
 			Msg("Serving directory.")
 		return httpServer.ListenAndServe()
 	})
 }
 
 func newHTTPServer() *http.Server {
-	httpServer := &http.Server{Addr: ":" + cfg.HTTP.Port, Handler: http.FileServer(http.Dir(cfg.Dir))}
+	httpServer := &http.Server{Addr: cfg.HTTP.Addr, Handler: http.FileServer(http.Dir(cfg.Dir))}
 
 	// You can register the shutdown handlers at any order, but do it before starting the app
 	app.RegisterShutdownHandler(


### PR DESCRIPTION
Changes the default admin port to bind to "localhost:9000" instead of just ":9000" so it is a little bit safer if port 9000 is not properly secured by the firewall.

Now, to expose admin port, it's necessary so explicitly set APP_ADMINSERVER_ADDR=:9000.