### PR TITLE
Disable 'depguard'

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ run:
 linters:
   disable-all: true
   enable:
+    #- depguard # Go linter that checks if package imports are in a list of acceptable packages
     #- exhaustive    # check exhaustiveness of enum switch statements
     #- funlen        # Tool for detection of long functions
     #- gocognit      # Computes and checks the cognitive complexity of functions
@@ -17,7 +18,6 @@ linters:
     #- lll           # Reports long lines
     #- scopelint     # Scopelint checks for unpinned variables in go programs
     - bodyclose # checks whether HTTP response body is closed successfully
-    - depguard # Go linter that checks if package imports are in a list of acceptable packages
     - dupl # Tool for code clone detection
     - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
     - exportloopref # checks for pointers to enclosing loop variables


### PR DESCRIPTION
The linter 'depguard' changed behavior and now blocks un-listed packages during linting. We are disabling this linter for now, until we decide how to best use it.