### PR TITLE
feat: self probe check

### DIFF
--- a/config.go
+++ b/config.go
@@ -41,6 +41,13 @@ type Config struct {
 		Config struct {
 			Output string
 		}
+		// Check executes a heathy check on the application.
+		Check struct {
+			// Ready checks if the application is ready to receive requests.
+			Ready bool
+			// Healthy checks if the application is alive.
+			Healthy bool
+		}
 	}
 }
 

--- a/examples/probes/main.go
+++ b/examples/probes/main.go
@@ -4,6 +4,11 @@
 //
 // To run this program in the commandline you could use:
 //   go run ./examples/probes/main.go -app-log-human --app-log-level=trace
+//
+// To check the probes statuses from outside the process you could use:
+//   go run ./examples/probes/main.go -app-log-human -app-check-ready
+//     or
+//   go run ./examples/probes/main.go -app-log-human -app-check-healthy
 
 package main
 


### PR DESCRIPTION
Dockerfile and docker-compose both have specific configuration for checking the health of a container. go-app already provides an URL for probing, but the container had to have wget o curl por probing.

This commit introduces a two new configuration that allows for the binary to check it's own probes.

if one of -app-check-ready or -app-check-healthy is set the binary will try to check http://localhost:port/ready or /healthy instead of bootstrap the new app.

Links: https://docs.docker.com/reference/dockerfile/#healthcheck