### PR TITLE
fix: flaky shutdown handler test

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           go-version: 1.22
       - name: Test
-        run: go test -v ./...
+        run: go test -v -race ./...
 
   vet:
     runs-on: ubuntu-latest

--- a/shutdownhandler_test.go
+++ b/shutdownhandler_test.go
@@ -118,8 +118,11 @@ func TestShutdownHandlerExecute_Timeout(t *testing.T) {
 	sh := &ShutdownHandler{
 		Name: "my_failed_shutdown_handler",
 		Handler: func(ctx context.Context) error {
+			// We will simulate a long-running operation that exceeds the timeout
+			// Reading from a nil channel will block indefinitely
+			var c <-chan struct{}
 			select {
-			case <-time.After(2 * time.Nanosecond):
+			case <-c:
 				return nil
 			case <-ctx.Done():
 				return errors.New("custom handler error on deadline exceeded")


### PR DESCRIPTION
One of the shutdown-handler's tests were failing inconsistently.

This was due a timer issue in which sometimes the functions finishes before the timeout kicks in.

The test was changed to not depend on a internal timer so the timeout will always kicks in.