### PR TITLE
fix(logger): corrige panic em Flatten ao encontrar ponteiro nil

### DIFF
--- a/logger/flatten.go
+++ b/logger/flatten.go
@@ -51,6 +51,11 @@ func flattenPrefixedToResult(value any, prefix string, m map[string]any) {
 		original = reflect.Indirect(original)
 		kind = original.Kind()
 	}
+
+	if original == (reflect.Value{}) {
+		return
+	}
+
 	t := original.Type()
 
 	switch kind {

--- a/logger/flatten_test.go
+++ b/logger/flatten_test.go
@@ -55,5 +55,20 @@ func TestFlatten(t *testing.T) {
 		Flatten(nil)
 	})
 
+	structF := struct {
+		FooE1 *struct {
+			FooF1 string
+		}
+	}{}
+	expectedFlattenF := ``
+	assert.NotPanics(t, func() {
+		Flatten(structF)
+	}, "test failed for struct F")
+	assert.Equal(t, expectedFlattenF, Flatten(structF), "test failed for struct F")
+
+	assert.NotPanics(t, func() {
+		Flatten(nil)
+	})
+
 	assert.Equal(t, "", Flatten(nil))
 }


### PR DESCRIPTION
**Problema**
Flatten utiliza reflection para percorrer structs e logar suas variáveis. Ao encontrar um campo do tipo ponteiro, o código chamava reflect.Indirect() para obter o valor apontado. Quando o ponteiro era nil, reflect.Indirect() retornava um reflect.Value zero (inválido), e a chamada subsequente a .Type() causava panic: call of reflect.Value.Type on zero Value.

Código exemplificando o panic: https://go.dev/play/p/-rj3Egvs8NT

**Solução**
A correção adiciona uma guarda logo após reflect.Indirect(): se o Value resultante for zero, a função retorna imediatamente, ignorando o campo nil sem propagar o panic.